### PR TITLE
Refactor of client-side validation logic to make it work properly

### DIFF
--- a/data/comments.js
+++ b/data/comments.js
@@ -7,14 +7,12 @@ export { createCommentDocument } from "../public/js/documentCreation.js";
 // insert to DB using insertOne. Return inserted comment.
 export async function createComment({ uid, meetingId, body }) {
     const comment = createCommentDocument({ uid, meetingId, body });
-    comment.meetingId = convertStrToObjectId(comment.meetingId, "Meeting ID String");
     const collection = await commentsCollection();
     const insertResponse = await collection.insertOne(comment);
     if (!insertResponse.acknowledged || !insertResponse.insertedId) throw new Error(`User ${uid} failed to post a new comment: ${body}`);
 
     // return comment with its ids converted to strings
     comment._id = comment._id.toString();
-    comment.meetingId = comment.meetingId.toString();
     return comment;
 }
 
@@ -27,7 +25,6 @@ export async function getCommentById(id) {
 
     // return comment with its ids converted to strings
     comment._id = comment._id.toString();
-    comment.meetingId = comment.meetingId.toString();
     return comment;
 }
 
@@ -40,7 +37,6 @@ export async function getAllComments() {
     //return all comments with id's mapped to strings
     comments = comments.map((comm) => {
         comm._id = comm._id.toString();
-        comm.meetingId = comm.meetingId.toString();
         return comm;
     });
     return comments;
@@ -58,7 +54,6 @@ export async function getUserComments(uid) {
     //return all comments with id's mapped to strings
     comments = comments.map((comm) => {
         comm._id = comm._id.toString();
-        comm.meetingId = comm.meetingId.toString();
         return comm;
     });
     return comments;
@@ -68,7 +63,6 @@ export async function getUserComments(uid) {
 export async function getMeetingComments(meetingId) {
     //TODO PV: Good idea to query meetings DB if meetingId is a real ID
     //Throw if it isn't.
-    meetingId = convertStrToObjectId(meetingId, "Meeting ID");
     const collection = await commentsCollection();
     let comments = await collection.find({ meetingId: meetingId }).toArray();
     if (!comments) throw new Error(`Could not get comments from meeting ID ${meetingId}`);
@@ -76,7 +70,6 @@ export async function getMeetingComments(meetingId) {
     //return all comments with id's mapped to strings
     comments = comments.map((comm) => {
         comm._id = comm._id.toString();
-        comm.meetingId = comm.meetingId.toString();
         return comm;
     });
     return comments;
@@ -84,14 +77,13 @@ export async function getMeetingComments(meetingId) {
 
 //remove comment and return it back
 export async function deleteComment(id) {
-    id = convertStrToObjectId(id, "Comment ID");
+    id = convertStrToObjectId(id, "Comment ID String");
     const collection = await commentsCollection();
     const removed = await collection.findOneAndDelete({ _id: id });
     if (!removed) throw new Error(`Failed to delete comment with ID ${id}`);
 
     // return comment with its ids converted to strings
     removed._id = removed._id.toString();
-    removed.meetingId = removed.meetingId.toString();
     return removed;
 }
 
@@ -107,7 +99,6 @@ export async function updateComment(id, newBody) {
 
     // return comment with its ids converted to strings
     updated._id = updated._id.toString();
-    updated.meetingId = updated.meetingId.toString();
     return updated;
 }
 

--- a/data/comments.js
+++ b/data/comments.js
@@ -1,13 +1,13 @@
 //Data functions for Comment objects.
 import { commentsCollection } from "../config/mongoCollections.js";
-import { ObjectId } from "mongodb";
-import { convertStrToObjectId, validateAndTrimString, validateStrAsObjectId, validateUserId } from "../utils/validation.js";
-import { createCommentDocument } from "../public/js/documentValidation.js";
-export { createCommentDocument } from "../public/js/documentValidation.js";
+import { convertStrToObjectId, validateAndTrimString, validateUserId } from "../utils/validation.js";
+import { createCommentDocument } from "../public/js/documentCreation.js";
+export { createCommentDocument } from "../public/js/documentCreation.js";
 
 // insert to DB using insertOne. Return inserted comment.
 export async function createComment({ uid, meetingId, body }) {
     const comment = createCommentDocument({ uid, meetingId, body });
+    comment.meetingId = convertStrToObjectId(comment.meetingId, "Meeting ID String");
     const collection = await commentsCollection();
     const insertResponse = await collection.insertOne(comment);
     if (!insertResponse.acknowledged || !insertResponse.insertedId) throw new Error(`User ${uid} failed to post a new comment: ${body}`);

--- a/data/users.js
+++ b/data/users.js
@@ -1,9 +1,9 @@
 // Data functions for user profile objects
 
-import * as validation from "../public/js/clientValidation.js";
+import * as validation from "../utils/validation.js";
 import { usersCollection } from "../config/mongoCollections.js";
-import { createUserDocument } from "../public/js/documentValidation.js";
-export { createUserDocument } from "../public/js/documentValidation.js";
+import { createUserDocument } from "../public/js/documentCreation.js";
+export { createUserDocument } from "../public/js/documentCreation.js";
 
 // create a user object and save it to the DB, then return the added object
 export async function createUser({ uid, password, firstName, lastName, description, profilePicture, availability }) {

--- a/data/users.js
+++ b/data/users.js
@@ -69,7 +69,7 @@ export async function updateUser(uid, { password, firstName, lastName, descripti
 // `isAdd` should be `true` to add the meetingId to the user, or `false` to remove the meetingId.
 export async function modifyUserMeeting(uid, meetingId, isAdd) {
     uid = validation.validateUserId(uid);
-    meetingId = validation.validateStrAsObjectId(meetingId);
+    meetingId = validation.validateStrAsObjectId(meetingId, "Meeting ID");
     const action = isAdd ? "$push" : "$pull";
 
     const collection = await usersCollection();

--- a/public/js/clientValidation.js
+++ b/public/js/clientValidation.js
@@ -80,6 +80,15 @@ export function validateUserId(uid) {
     return validateAlphanumeric(uid, "User ID", 3).toLowerCase();
 }
 
+// Throw an error if a string is not valid or does not represent not a valid ObjectId.
+// Return the trimmed string if it represents a valid ObjectId.
+export function validateStrAsObjectId(id, label) {
+    id = validateAndTrimString(id, label);
+    const validObjectIdRegex = /^[0-9a-fA-F]{24}$/; // replaces ObjectId.isValid() so this can be used on client side
+    if (id.length !== 24 || !validObjectIdRegex.test(id)) throw new ValidationError(`${label} "${id}" is not valid`);
+    return id;
+}
+
 //
 // ============ Misc Validation & Utility ============
 //

--- a/public/js/documentCreation.js
+++ b/public/js/documentCreation.js
@@ -37,7 +37,7 @@ export function createCommentDocument({ uid, meetingId, body }) {
     // (currently only validated as string)
 
     uid = validation.validateUserId(uid);
-    meetingId = validation.validateAndTrimString(meetingId, "Meeting ID");
+    meetingId = validation.validateStrAsObjectId(meetingId, "Meeting ID");
     body = validation.validateAndTrimString(body, "Comment Text", false);
     let timestamp = new Date();
     // create and return document

--- a/public/js/documentCreation.js
+++ b/public/js/documentCreation.js
@@ -36,9 +36,9 @@ export function createCommentDocument({ uid, meetingId, body }) {
     // TODO BL: Sanitize comment body for security vulnerabilities
     // (currently only validated as string)
 
-    uid = validateUserId(uid);
-    meetingId = convertStrToObjectId(meetingId, "Meeting ID");
-    body = validateAndTrimString(body, "Comment Text", false);
+    uid = validation.validateUserId(uid);
+    meetingId = validation.convertStrToObjectId(meetingId, "Meeting ID");
+    body = validation.validateAndTrimString(body, "Comment Text", false);
     let timestamp = new Date();
 
     // create and return document

--- a/public/js/documentCreation.js
+++ b/public/js/documentCreation.js
@@ -37,10 +37,9 @@ export function createCommentDocument({ uid, meetingId, body }) {
     // (currently only validated as string)
 
     uid = validation.validateUserId(uid);
-    meetingId = validation.convertStrToObjectId(meetingId, "Meeting ID");
+    meetingId = validation.validateAndTrimString(meetingId, "Meeting ID");
     body = validation.validateAndTrimString(body, "Comment Text", false);
     let timestamp = new Date();
-
     // create and return document
     const comment = {
         uid: uid,

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -4,6 +4,7 @@ import "../public/js/clientValidation.js";
 
 // Re-export common validation also used client-side
 export * from "../public/js/clientValidation.js";
+import * as clientValidation from "../public/js/clientValidation.js";
 
 //
 // ============ Database-Related Validation ============
@@ -12,15 +13,15 @@ export * from "../public/js/clientValidation.js";
 // Throw an error if a string is not valid or is not a valid `uid`.
 // If the `uid` is valid, return a boolean indicating whether it is already in use in the DB.
 export async function isUserIdUnique(uid) {
-    uid = validateUserId(uid);
+    uid = clientValidation.validateUserId(uid);
     return !(await getAllUserIDs()).includes(uid); // return `false` if `uid` is already found in the DB
 }
 
 // Throw an error if a string is not valid or does not represent not a valid ObjectId.
 // Return the trimmed string if it represents a valid ObjectId.
 export function validateStrAsObjectId(id, label) {
-    id = validateAndTrimString(id, label);
-    if (!ObjectId.isValid(id)) throw new ValidationError(`${label} "${id}" is not valid`);
+    id = clientValidation.validateAndTrimString(id, label);
+    if (!ObjectId.isValid(id)) throw new clientValidation.ValidationError(`${label} "${id}" is not valid`);
     return id;
 }
 

--- a/utils/validation.js
+++ b/utils/validation.js
@@ -17,16 +17,8 @@ export async function isUserIdUnique(uid) {
     return !(await getAllUserIDs()).includes(uid); // return `false` if `uid` is already found in the DB
 }
 
-// Throw an error if a string is not valid or does not represent not a valid ObjectId.
-// Return the trimmed string if it represents a valid ObjectId.
-export function validateStrAsObjectId(id, label) {
-    id = clientValidation.validateAndTrimString(id, label);
-    if (!ObjectId.isValid(id)) throw new clientValidation.ValidationError(`${label} "${id}" is not valid`);
-    return id;
-}
-
 // Throw an error if a string is not valid or is not a valid ObjectId.
 // Return the converted ObjectID object if it is valid.
 export function convertStrToObjectId(id, label) {
-    return ObjectId.createFromHexString(validateStrAsObjectId(id, label));
+    return ObjectId.createFromHexString(clientValidation.validateStrAsObjectId(id, label));
 }


### PR DESCRIPTION
Client code for server-side validation was now imported properly. 

Also, the `comments` collection now stores `meetingId` as the stringified representation of a Meeting's `_id` (which is still an ObjectId) so the `meetingId` can be validated on the client side and interop more easily with string-based data functions.